### PR TITLE
updated shebangs in python scripts

### DIFF
--- a/analysis/scripts/chromosomeMutator.py
+++ b/analysis/scripts/chromosomeMutator.py
@@ -1,3 +1,5 @@
+#!/usr/bin/python2
+
 def chromosomeMutator(chromosome,heterozygosity):
 	import random
 	A="CGT"

--- a/analysis/scripts/parameteranalysis.py
+++ b/analysis/scripts/parameteranalysis.py
@@ -1,6 +1,6 @@
+#!/usr/bin/python2
 #Given a reference sequence, introduce a  given rate of heterozygosity and create Illumina reads based on the wanted coverage level, readlength, and read duplication level.
 
-#!/usr/bin/python
 import os
 import os.path
 import gzip

--- a/analysis/scripts/run_jelly.py
+++ b/analysis/scripts/run_jelly.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/python2
 import os
 import os.path
 import sys


### PR DESCRIPTION
On latter Ubuntus (i.e. 20.04), the default python is python3 (also python-is-python3 package is oftentimes installed from my experience). Scripts that are used by genomescope are written in python2. 

I've changed shebangs in order to run the scripts in python2, even if default system python is python3.
